### PR TITLE
Use new slice when writing to `responseWriter`

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,9 @@ type responseWriter struct {
 }
 
 func (rw *responseWriter) Write(b []byte) (int, error) {
-	rw.writes = append(rw.writes, b)
+	buf := make([]byte, len(b))
+	copy(buf, b)
+	rw.writes = append(rw.writes, buf)
 	return len(b), nil
 }
 


### PR DESCRIPTION
Without this change, I get a rather baffling behavior when calling these endpoints with a cal to `log.printLn` after `app.ServeHTTP` and before `nw.flush()` like:

```
		nw := &responseWriter{ResponseWriter: w}
		app.ServeHTTP(nw, r)

		log.Println("TESTING")

		nw.flush()
```

I get:

```
 # with `go run main.go`
 $ curl localhost:3000
TESTING
o!</h1>
```

Which, is quite worrying to me as it looks like the call to `flush` is using some memory location that it shouldn't have access to. If you know why this is happening please let me know.

In any case, copying the data to a new vector or using `[]byte` as field in the struct and then copying bytes one by one also works.


